### PR TITLE
Remove licenses entry

### DIFF
--- a/vaadin-login-flow-testbench/pom.xml
+++ b/vaadin-login-flow-testbench/pom.xml
@@ -14,14 +14,6 @@
 
     <name>Vaadin Login Testbench API</name>
 
-    <licenses>
-        <license>
-            <name>Apache License Version 2.0</name>
-            <distribution>repo</distribution>
-            <url>http://www.apache.org/licenses/LICENSE-2.0</url>
-        </license>
-    </licenses>
-
     <dependencies>
         <dependency>
             <groupId>com.vaadin</groupId>

--- a/vaadin-login-flow/pom.xml
+++ b/vaadin-login-flow/pom.xml
@@ -14,14 +14,6 @@
 
     <name>Vaadin Login</name>
 
-    <licenses>
-        <license>
-            <name>Apache License Version 2.0</name>
-            <distribution>repo</distribution>
-            <url>http://www.apache.org/licenses/LICENSE-2.0</url>
-        </license>
-    </licenses>
-
     <dependencies>
         <!--Provided scoped-->
         <dependency>


### PR DESCRIPTION
Apache 2.0 is coming from `vaadin-parent` > `flow-component-base`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-login-flow/58)
<!-- Reviewable:end -->
